### PR TITLE
Implement new App lock interfaces from Rapidcore

### DIFF
--- a/src/Locking/RedisDistributedAppLockProvider.cs
+++ b/src/Locking/RedisDistributedAppLockProvider.cs
@@ -6,10 +6,10 @@ using StackExchange.Redis;
 namespace RapidCore.Redis.Locking
 {
     /// <summary>
-    /// Implementation of a <see cref="IDistributedAppLocker"/> that utilizes Redis as the backing store for 
+    /// Implementation of a <see cref="IDistributedAppLockProvider"/> that utilizes Redis as the backing store for 
     /// creating the locks
     /// </summary>
-    public class RedisDistributedAppLocker : IDistributedAppLocker
+    public class RedisDistributedAppLockProvider : IDistributedAppLockProvider
     {
         private readonly IConnectionMultiplexer _redisMuxer;
         
@@ -17,7 +17,7 @@ namespace RapidCore.Redis.Locking
         /// Create a new instance of the locker
         /// </summary>
         /// <param name="redisMuxer">A connected instance of a redis muxer</param>
-        public RedisDistributedAppLocker(IConnectionMultiplexer redisMuxer)
+        public RedisDistributedAppLockProvider(IConnectionMultiplexer redisMuxer)
         {
             _redisMuxer = redisMuxer;
         }

--- a/src/rapidcore.redis.csproj
+++ b/src/rapidcore.redis.csproj
@@ -18,7 +18,9 @@
     <CodeAnalysisRuleSet>../stylecop.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="RapidCore" Version="0.7.0" />
+    <PackageReference Include="RapidCore">
+      <Version>0.8.0</Version>
+    </PackageReference>
     <PackageReference Include="StackExchange.Redis" Version="1.2.3" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta001" PrivateAssets="All" />
     <DotNetCliToolReference Include="dotnet-version-cli" Version="0.3.0" />

--- a/test/unit/Locking/RedisDistributedAppLockProviderTest.cs
+++ b/test/unit/Locking/RedisDistributedAppLockProviderTest.cs
@@ -6,7 +6,7 @@ using Xunit;
 
 namespace RapidCore.Redis.UnitTests.Locking
 {
-    public class RedisDistributedAppLockerTest
+    public class RedisDistributedAppLockProviderTest
     {
         [Fact]
         public void Test_does_create_new_redis_client()
@@ -21,7 +21,7 @@ namespace RapidCore.Redis.UnitTests.Locking
                 A<RedisValue>.Ignored,
                 A<TimeSpan>.Ignored,
                 A<CommandFlags>.Ignored)).Returns(true);
-            var locker = new RedisDistributedAppLocker(manager);
+            var locker = new RedisDistributedAppLockProvider(manager);
 
             locker.Acquire(lockName);
 
@@ -42,7 +42,7 @@ namespace RapidCore.Redis.UnitTests.Locking
                 A<RedisValue>.Ignored,
                 A<TimeSpan>.Ignored,
                 A<CommandFlags>.Ignored)).Returns(true);
-            var locker = new RedisDistributedAppLocker(manager);
+            var locker = new RedisDistributedAppLockProvider(manager);
 
             locker.Acquire(lockName);
 


### PR DESCRIPTION
- Renames to LockProvider to adhere to the interface
- Adds tests to show that new functionality works
- Fixes bug where IsActive was not flagged appropriately when lock was disposed