### PR TITLE
Target dotnet 4.6 as well

### DIFF
--- a/rapidcore.redis.sln
+++ b/rapidcore.redis.sln
@@ -1,7 +1,6 @@
-
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26124.0
+VisualStudioVersion = 15.0.26430.13
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "rapidcore.redis", "src\rapidcore.redis.csproj", "{BA9A80CA-8E71-4BB4-AC3D-4FE8542ED429}"
 EndProject
@@ -20,46 +19,46 @@ Global
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
 	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
-	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{BA9A80CA-8E71-4BB4-AC3D-4FE8542ED429}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{BA9A80CA-8E71-4BB4-AC3D-4FE8542ED429}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{BA9A80CA-8E71-4BB4-AC3D-4FE8542ED429}.Debug|x64.ActiveCfg = Debug|x64
-		{BA9A80CA-8E71-4BB4-AC3D-4FE8542ED429}.Debug|x64.Build.0 = Debug|x64
-		{BA9A80CA-8E71-4BB4-AC3D-4FE8542ED429}.Debug|x86.ActiveCfg = Debug|x86
-		{BA9A80CA-8E71-4BB4-AC3D-4FE8542ED429}.Debug|x86.Build.0 = Debug|x86
+		{BA9A80CA-8E71-4BB4-AC3D-4FE8542ED429}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{BA9A80CA-8E71-4BB4-AC3D-4FE8542ED429}.Debug|x64.Build.0 = Debug|Any CPU
+		{BA9A80CA-8E71-4BB4-AC3D-4FE8542ED429}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{BA9A80CA-8E71-4BB4-AC3D-4FE8542ED429}.Debug|x86.Build.0 = Debug|Any CPU
 		{BA9A80CA-8E71-4BB4-AC3D-4FE8542ED429}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{BA9A80CA-8E71-4BB4-AC3D-4FE8542ED429}.Release|Any CPU.Build.0 = Release|Any CPU
-		{BA9A80CA-8E71-4BB4-AC3D-4FE8542ED429}.Release|x64.ActiveCfg = Release|x64
-		{BA9A80CA-8E71-4BB4-AC3D-4FE8542ED429}.Release|x64.Build.0 = Release|x64
-		{BA9A80CA-8E71-4BB4-AC3D-4FE8542ED429}.Release|x86.ActiveCfg = Release|x86
-		{BA9A80CA-8E71-4BB4-AC3D-4FE8542ED429}.Release|x86.Build.0 = Release|x86
+		{BA9A80CA-8E71-4BB4-AC3D-4FE8542ED429}.Release|x64.ActiveCfg = Release|Any CPU
+		{BA9A80CA-8E71-4BB4-AC3D-4FE8542ED429}.Release|x64.Build.0 = Release|Any CPU
+		{BA9A80CA-8E71-4BB4-AC3D-4FE8542ED429}.Release|x86.ActiveCfg = Release|Any CPU
+		{BA9A80CA-8E71-4BB4-AC3D-4FE8542ED429}.Release|x86.Build.0 = Release|Any CPU
 		{6F41AD23-5478-4C7B-B710-4604C2447AE5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{6F41AD23-5478-4C7B-B710-4604C2447AE5}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{6F41AD23-5478-4C7B-B710-4604C2447AE5}.Debug|x64.ActiveCfg = Debug|x64
-		{6F41AD23-5478-4C7B-B710-4604C2447AE5}.Debug|x64.Build.0 = Debug|x64
-		{6F41AD23-5478-4C7B-B710-4604C2447AE5}.Debug|x86.ActiveCfg = Debug|x86
-		{6F41AD23-5478-4C7B-B710-4604C2447AE5}.Debug|x86.Build.0 = Debug|x86
+		{6F41AD23-5478-4C7B-B710-4604C2447AE5}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{6F41AD23-5478-4C7B-B710-4604C2447AE5}.Debug|x64.Build.0 = Debug|Any CPU
+		{6F41AD23-5478-4C7B-B710-4604C2447AE5}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{6F41AD23-5478-4C7B-B710-4604C2447AE5}.Debug|x86.Build.0 = Debug|Any CPU
 		{6F41AD23-5478-4C7B-B710-4604C2447AE5}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6F41AD23-5478-4C7B-B710-4604C2447AE5}.Release|Any CPU.Build.0 = Release|Any CPU
-		{6F41AD23-5478-4C7B-B710-4604C2447AE5}.Release|x64.ActiveCfg = Release|x64
-		{6F41AD23-5478-4C7B-B710-4604C2447AE5}.Release|x64.Build.0 = Release|x64
-		{6F41AD23-5478-4C7B-B710-4604C2447AE5}.Release|x86.ActiveCfg = Release|x86
-		{6F41AD23-5478-4C7B-B710-4604C2447AE5}.Release|x86.Build.0 = Release|x86
+		{6F41AD23-5478-4C7B-B710-4604C2447AE5}.Release|x64.ActiveCfg = Release|Any CPU
+		{6F41AD23-5478-4C7B-B710-4604C2447AE5}.Release|x64.Build.0 = Release|Any CPU
+		{6F41AD23-5478-4C7B-B710-4604C2447AE5}.Release|x86.ActiveCfg = Release|Any CPU
+		{6F41AD23-5478-4C7B-B710-4604C2447AE5}.Release|x86.Build.0 = Release|Any CPU
 		{587743BB-C561-434C-8C40-94A2E8194C3F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{587743BB-C561-434C-8C40-94A2E8194C3F}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{587743BB-C561-434C-8C40-94A2E8194C3F}.Debug|x64.ActiveCfg = Debug|x64
-		{587743BB-C561-434C-8C40-94A2E8194C3F}.Debug|x64.Build.0 = Debug|x64
-		{587743BB-C561-434C-8C40-94A2E8194C3F}.Debug|x86.ActiveCfg = Debug|x86
-		{587743BB-C561-434C-8C40-94A2E8194C3F}.Debug|x86.Build.0 = Debug|x86
+		{587743BB-C561-434C-8C40-94A2E8194C3F}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{587743BB-C561-434C-8C40-94A2E8194C3F}.Debug|x64.Build.0 = Debug|Any CPU
+		{587743BB-C561-434C-8C40-94A2E8194C3F}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{587743BB-C561-434C-8C40-94A2E8194C3F}.Debug|x86.Build.0 = Debug|Any CPU
 		{587743BB-C561-434C-8C40-94A2E8194C3F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{587743BB-C561-434C-8C40-94A2E8194C3F}.Release|Any CPU.Build.0 = Release|Any CPU
-		{587743BB-C561-434C-8C40-94A2E8194C3F}.Release|x64.ActiveCfg = Release|x64
-		{587743BB-C561-434C-8C40-94A2E8194C3F}.Release|x64.Build.0 = Release|x64
-		{587743BB-C561-434C-8C40-94A2E8194C3F}.Release|x86.ActiveCfg = Release|x86
-		{587743BB-C561-434C-8C40-94A2E8194C3F}.Release|x86.Build.0 = Release|x86
+		{587743BB-C561-434C-8C40-94A2E8194C3F}.Release|x64.ActiveCfg = Release|Any CPU
+		{587743BB-C561-434C-8C40-94A2E8194C3F}.Release|x64.Build.0 = Release|Any CPU
+		{587743BB-C561-434C-8C40-94A2E8194C3F}.Release|x86.ActiveCfg = Release|Any CPU
+		{587743BB-C561-434C-8C40-94A2E8194C3F}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{6F41AD23-5478-4C7B-B710-4604C2447AE5} = {532C8B26-92F2-4EC6-A483-6346CC0692B8}

--- a/src/rapidcore.redis.csproj
+++ b/src/rapidcore.redis.csproj
@@ -1,6 +1,6 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard1.6</TargetFramework>
+    <TargetFrameworks>netstandard1.6;net46</TargetFrameworks>
     <RootNamespace>RapidCore.Redis</RootNamespace>
     <Version>0.1.0</Version>
     <Title>RapidCore.Redis</Title>
@@ -19,9 +19,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="RapidCore">
-      <Version>0.8.0</Version>
+      <Version>0.13.0</Version>
     </PackageReference>
-    <PackageReference Include="StackExchange.Redis" Version="1.2.3" />
+    <PackageReference Include="StackExchange.Redis" Version="1.2.4" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta001" PrivateAssets="All" />
     <DotNetCliToolReference Include="dotnet-version-cli" Version="0.3.0" />
   </ItemGroup>


### PR DESCRIPTION
- Add targeting of dotnet 4.6. All APIs in the library are compatible.
- Update to rapidcore 0.13
- Update to stackexchange redis 1.2.4
- Visual studio automatic changes to solution file