### PR TITLE
Add Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: csharp
+dist: trusty
+sudo: required
+mono: none
+services:
+  - redis-server
+dotnet: 1.0.4
+script:
+  - chmod +x ./Build.sh && ./Build.sh --quiet verify

--- a/Build.sh
+++ b/Build.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+# Perform the actual build
+dotnet restore \
+&& dotnet build -c Release -f netstandard1.6 src/rapidcore.redis.csproj \
+&& dotnet test test/unit/unittests.csproj -c Release -f netcoreapp1.1 \
+&& dotnet test test/functional/functionaltest.csproj -c Release -f netcoreapp1.1


### PR DESCRIPTION
This PR enables Travis CI builds

- Validate that things compile on Linux
- Run the functional tests as we can start a redis service on Travis CI